### PR TITLE
`roundPixels`: fix default `Unit.px` as `xmlValue`.

### DIFF
--- a/lib/src/svg/widgets/abstract/unit_converter.dart
+++ b/lib/src/svg/widgets/abstract/unit_converter.dart
@@ -3,7 +3,7 @@ import 'package:scidart_plot/src/svg/enums/unit.dart';
 
 /// Round pixels values to 1 decimal point max.
 String roundPixels(double val, Unit? unit) {
-  return '${truncate(val, 1)}${unit?.xmlValue ?? Unit.px}';
+  return '${truncate(val, 1)}${(unit ?? Unit.px).xmlValue}';
 }
 
 /// Round only pixel number without include the unity.


### PR DESCRIPTION
In recent Dart SDK (using 2.18.2):

When the parameter `unit` (enum `Unit`) is `null` it generates a XML value: `Unit.px`

This will generate an invalid SVG.

Now it was fixed to generate `px` as the XML value.